### PR TITLE
feat(gulp-tasks): handle ts:compile fail

### DIFF
--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -50,7 +50,10 @@ function createTasks(packageName, options = {}) {
         const tsProject = ts.createProject(options.tsConfigFilename, { declaration: true });
         const tsResult = gulp.src(options.tsGlob)
             .pipe(sourcemaps.init())
-            .pipe(tsProject());
+            .pipe(tsProject())
+            .once('error', function () {
+                this.once('finish', () => process.exit(1));
+            });
 
         return es
             .merge(tsResult.js, tsResult.dts)


### PR DESCRIPTION
Обработка ошибок компиляции тайпскрипта.
Нужно, чтобы можно было обработать их на гитхуке, да и не только.