### PR TITLE
feat(*): add definitions generation for composed components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    extends: require.resolve('arui-presets/eslint'),
+    rules: {
+        'func-names': 0
+    }
+};

--- a/component-docs.js
+++ b/component-docs.js
@@ -22,12 +22,12 @@ function componentDocs(libraryName) {
         const content = file.contents.toString('utf8');
         const componentName = path.parse(file.path).name;
         const description = structureForFile(content, componentName);
-        const doc = ejs.render(TEMPLATE_COMPONENT, { component: description, libraryName: libraryName });
+        const doc = ejs.render(TEMPLATE_COMPONENT, { component: description, libraryName });
 
         callback(null, new Vinyl({
             cwd: file.cwd,
             base: file.base,
-            path: path.dirname(file.path) + '/README.md',
+            path: `${path.dirname(file.path)}/README.md`,
             contents: new Buffer(doc)
         }));
     }

--- a/component-package.js
+++ b/component-package.js
@@ -10,8 +10,8 @@ const Vinyl = require('vinyl');
  */
 function getComponentPackage(componentName) {
     return JSON.stringify({
-        main: componentName + '.js',
-        types: componentName + '.d.ts',
+        main: `${componentName}.js`,
+        types: `${componentName}.d.ts`
     });
 }
 
@@ -31,7 +31,7 @@ function componentPackage() {
         callback(null, new Vinyl({
             cwd: file.cwd,
             base: file.base,
-            path: path.dirname(file.path) + '/package.json',
+            path: `${path.dirname(file.path)}/package.json`,
             contents: new Buffer(getComponentPackage(componentName))
         }));
     }

--- a/component-typings.js
+++ b/component-typings.js
@@ -20,11 +20,11 @@ function componentTypings(libraryName) {
             callback(null, new Vinyl({
                 cwd: file.cwd,
                 base: file.base,
-                path: path.join(path.dirname(file.path), componentName + '.d.ts'),
+                path: path.join(path.dirname(file.path), `${componentName}.d.ts`),
                 contents: Buffer(definitionsContent)
             }));
         }).catch((e) => {
-            console.log(e);
+            console.error(e);
         });
     }
 

--- a/getTypingsContentForReactComponent.js
+++ b/getTypingsContentForReactComponent.js
@@ -38,41 +38,107 @@ function getReactComponentDefinitionsContent(info, componentModuleName, projectN
     /* TODO: сделать полноценное наследование doc.composes.map(({ componentName, filePath }) =>
         `import { ${componentName}Props } from './${path.relative(path.dirname(doc.filePath), filePath )}'`
     )*/
-    /* TODO: сделать генерацию примитивов
-        Сейчас генерятся any, как и в предыдущем случае
-        добавить сначала для примитивов, потом для shape etc
-    )*/
-    const content = (`
-    declare module '${moduleName}' {
-        import { Component } from 'react';
-        
-        export interface ${componentName}Props {
-            ${Object.keys(info.props).map(propName => {
-                const { required, type, description } = info.props[propName];
-                return `
-                    /**
-                     * ${ description }
-                     */
-                    ${propName}${required? '': '?'}: ${'any' /* type.name */};
-                `;
-            }).join('')}
-        }
+    const content = (
+        `declare module '${moduleName}' {
+            import { Component, ReactNode } from 'react';
+            
+            export interface ${componentName}Props {
+                ${Object.keys(info.props).map(propName => {
+                    const { required, type, description, docblock } = info.props[propName];
+                    return (
+                        `${stringifyDescription(description, docblock)}
+                        ${propName}${required? '': '?'}: ${stringifyType(type)};`
+                    );
+                }).join('')}
+            }
 
-        export default class ${componentName} extends Component<${componentName}Props, any>{
-            ${info.methods.map(({ name, docblock, params, description }) => `
-                /**
-                 * ${description}
-                 */
-                ${name}(
-                    ${params.map(({ name }) => `${name}: any`).join(',')}
-                ): any;
-            `).join('')}
-        }
-     }
-    `);
+            ${stringifyDescription(info.description, info.docblock)}
+            export default class ${componentName} extends Component<${componentName}Props, any> {
+                ${info.methods.map(({ name, docblock, params, description }) => (
+                    `${stringifyDescription(description, docblock)}
+                    ${name}(${params.map(({ name }) => `${name}: any`).join(',')}): any;`
+                )).join('')}
+            }
+        }`
+    );
     return content;
 }
 
+function stringifyType(type){
+    switch (type.name) {
+        case 'string': 
+            return 'string';
+        case 'number':
+            return 'number';
+        case 'bool':
+            return 'boolean';
+        case 'array':
+            return 'Array<any>';
+        case 'node':
+            return 'ReactNode';
+        case 'union': 
+            return stringifyUnion(type);
+        case 'func':
+            return 'Function';
+        case 'enum':
+            return stringifyEnum(type);  
+        case 'arrayOf':
+            return stringifyArray(type);  
+        case 'shape':
+            return stringifyShape(type);
+        case 'objectOf':
+            return stringifyObjectOf(type);
+        case 'object':
+            return 'object';
+        case 'any':
+            return 'any';    
+        default:
+            return 'any' + 
+                `/* Не нашелся встроенный тип для типа ${JSON.stringify(type)}
+                 * https://github.com/alfa-laboratory/library-utils/issues/new 
+                 */`;
+    }
+}
+
+function stringifyArray(type) {
+    return `Array<${stringifyType(type.value)}>`;
+}
+
+function stringifyEnum(type) {
+    return `${type.value.map(({value})=> value).join(' | ')}`;
+}
+
+function stringifyUnion(type) {
+    return `${type.value.map(type => stringifyType(type)).join(' | ')}`
+}
+
+function stringifyShape(type) {
+    const fields = type.value;
+    return `{
+        ${Object.keys(fields).map(fieldName => stringifyField(fieldName, fields[fieldName])).join(';\n')}
+    }`;
+}
+
+function stringifyObjectOf(type) {
+    const fieldType = type.value;
+    return `{
+        [key: any]: ${stringifyType(fieldType)};
+    }`;
+}
+
+function stringifyField(name, type) {
+    return (
+        `${stringifyDescription(type.description, type.docblock)}
+        ${name}${type.required? '': '?'}: ${stringifyType(type)}`
+    );
+}
+
+function stringifyDescription(description, docblock) {
+    return !description? '':`
+    /**
+     * ${description}
+     */`;
+}
 
 function getFormattedReactComponentDefinitionsContent(filePath, projectName) {
     return new Promise((resolve, reject) => {

--- a/getTypingsContentForReactComponent.js
+++ b/getTypingsContentForReactComponent.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const path = require('path');
+const reactDockGen = require('react-docgen');
+const upperCamelCase = require('uppercamelcase');
+const tsfmt = require("typescript-formatter");
+
+
+const documentation = { };
+function getReactComponentInfo(filePath, resolver, handlers) {
+    if (documentation[filePath]) {
+        return documentation[filePath];
+    }
+    const content = fs.readFileSync(filePath);
+    const info = reactDockGen.parse(content, resolver, handlers);
+    info.filePath = filePath;
+    if (info.composes) {
+        info.composes = info.composes.map((relativePath) => {
+            const composeComponentPath = path.resolve(path.dirname(filePath), `${relativePath}.jsx`);
+            return getReactComponentInfo(composeComponentPath, resolver, handlers);
+        });
+    } else {
+        info.composes = [];
+    }
+    // filter public methods
+    info.methods = info.methods.filter(({docblock}) => docblock && docblock.indexOf('@public') !== -1);
+    // extends props for composed components
+    info.props = info.composes.reduce((prev, item) => Object.assign({}, prev, item.props), info.props || {});
+    documentation[filePath] = info;
+    return info;
+}
+
+function getReactComponentDefinitionsContent(info, componentModuleName, projectName) {
+    const moduleName = `${projectName}/${componentModuleName}`;
+    const componentName = upperCamelCase(componentModuleName);
+    /* TODO: сделать полноценное наследование
+        doc.composes.length > 0? `extends ${doc.composes.map(({componentName}) => `${componentName}Props`).join(' & ')}`: ''
+    */
+    /* TODO: сделать полноценное наследование doc.composes.map(({ componentName, filePath }) =>
+        `import { ${componentName}Props } from './${path.relative(path.dirname(doc.filePath), filePath )}'`
+    )*/
+    /* TODO: сделать генерацию примитивов
+        Сейчас генерятся any, как и в предыдущем случае
+        добавить сначала для примитивов, потом для shape etc
+    )*/
+    const content = (`
+    declare module '${moduleName}' {
+        import { Component } from 'react';
+        
+        export interface ${componentName}Props {
+            ${Object.keys(info.props).map(propName => {
+                const { required, type, description } = info.props[propName];
+                return `
+                    /**
+                     * ${ description }
+                     */
+                    ${propName}${required? '': '?'}: ${'any' /* type.name */};
+                `;
+            }).join('')}
+        }
+
+        export default class ${componentName} extends Component<${componentName}Props, any>{
+            ${info.methods.map(({ name, docblock, params, description }) => `
+                /**
+                 * ${description}
+                 */
+                ${name}(
+                    ${params.map(({ name }) => `${name}: any`).join(',')}
+                ): any;
+            `).join('')}
+        }
+     }
+    `);
+    return content;
+}
+
+
+function getFormattedReactComponentDefinitionsContent(filePath, projectName) {
+    return new Promise((resolve, reject) => {
+        const componentName = path.parse(filePath).name;
+        const componentInfo = getReactComponentInfo(filePath, undefined, undefined);
+        const definitionsContent = getReactComponentDefinitionsContent(componentInfo, componentName, projectName);
+        tsfmt.processString("", definitionsContent, {
+            dryRun: true,
+            replace: false,
+            verify: false,
+            tsconfig: false,
+            tslint: false,
+            editorconfig: false,
+            tsfmt: true
+        }).then(result => {
+            const formattedDefinitionsContent = result.dest
+            resolve(formattedDefinitionsContent);
+        });
+    });
+}
+
+module.exports = getFormattedReactComponentDefinitionsContent;

--- a/library-doc.js
+++ b/library-doc.js
@@ -9,9 +9,10 @@ const TEMPLATE_INDEX = fs.readFileSync(path.join(__dirname, '/docs-templates/ind
 
 /**
  * Gulp plugin to get index README file for all components.
- *
+ * @param {String} libraryName Library name, will be used in docs.
  * @returns {Function}
  */
+
 function libraryDoc(libraryName) {
     let latestFile;
     const components = [];
@@ -39,7 +40,7 @@ function libraryDoc(libraryName) {
             return 0;
         });
 
-        const content = ejs.render(TEMPLATE_INDEX, { components: components, libraryName });
+        const content = ejs.render(TEMPLATE_INDEX, { components, libraryName });
         this.push(new Vinyl({
             path: latestFile.path,
             contents: new Buffer(content)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "gulp-typescript": "^3.1.5",
     "react-component-info": "^1.0.0",
     "react-docgen": "^2.15.0",
-    "react-to-typescript-definitions": "^0.18.1",
     "through2": "^2.0.3",
     "typescript": "^2.2.1",
     "typescript-formatter": "^5.2.0",
@@ -34,6 +33,13 @@
     "release-minor": "npm version minor -m 'chore(*): minor version'",
     "release-major": "npm version major -m 'chore(*): major version'",
     "version": "git fetch --tags",
-    "postversion": "git push origin master && git push --tags && npm publish"
+    "precommit": "npm run lint",
+    "postversion": "git push origin master && git push --tags && npm publish",
+    "lint": "eslint --fix ./*.js "
+  },
+  "devDependencies": {
+    "arui-presets": "^2.2.0",
+    "eslint": "^3.19.0",
+    "husky": "^0.13.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,12 @@
     "gulp-sourcemaps": "2.4.1",
     "gulp-typescript": "^3.1.5",
     "react-component-info": "^1.0.0",
+    "react-docgen": "^2.15.0",
     "react-to-typescript-definitions": "^0.18.1",
     "through2": "^2.0.3",
     "typescript": "^2.2.1",
+    "typescript-formatter": "^5.2.0",
+    "uppercamelcase": "^3.0.0",
     "vinyl": "^2.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "version": "git fetch --tags",
     "precommit": "npm run lint",
     "postversion": "git push origin master && git push --tags && npm publish",
-    "lint": "eslint --fix ./*.js "
+    "lint": "eslint ./*.js"
   },
   "devDependencies": {
     "arui-presets": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,9 +94,11 @@ asty@~1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/asty/-/asty-1.4.8.tgz#4dbc11c25a61abe5fba4f2f6d770d7ca41e607ff"
 
-async@^1.4.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+async@^2.1.4:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.1.tgz#62a56b279c98a11d0987096a01cc3eeb8eb7bbd7"
+  dependencies:
+    lodash "^4.14.0"
 
 atob@~1.1.0:
   version "1.1.3"
@@ -228,6 +230,10 @@ beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
+bluebird@^3.0.5:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -276,6 +282,10 @@ camelcase@^1.2.1:
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 chalk@^0.5.0:
   version "0.5.1"
@@ -330,6 +340,10 @@ commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commandpost@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commandpost/-/commandpost-1.0.1.tgz#7d7e3e69ae8fe7d6949341e91596ede9b2d631fd"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -477,6 +491,15 @@ duplexify@^3.2.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+editorconfig@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.2.tgz#8e57926d9ee69ab6cb999f027c2171467acceb35"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    sigmund "^1.0.1"
 
 ejs@^2.5.6:
   version "2.5.6"
@@ -909,7 +932,7 @@ gulp-sourcemaps@1.6.0:
     through2 "^2.0.0"
     vinyl "^1.0.0"
 
-gulp-sourcemaps@~2.4.1:
+gulp-sourcemaps@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.4.1.tgz#8f65dc5c0d07b2fd5c88bc60ec7f13e56716bf74"
   dependencies:
@@ -1487,7 +1510,7 @@ lodash.values@~2.4.1:
   dependencies:
     lodash.keys "~2.4.1"
 
-lodash@^4.2.0, lodash@~4.17.2:
+lodash@^4.14.0, lodash@^4.2.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1515,6 +1538,12 @@ lower-case@^1.1.1:
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
 
 map-cache@^0.2.0:
   version "0.2.2"
@@ -1872,6 +1901,10 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 quote-stream@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/quote-stream/-/quote-stream-0.0.0.tgz#cde29e94c409b16e19dc7098b89b6658f9721d3b"
@@ -1895,11 +1928,11 @@ react-component-info@^1.0.0:
     react-docgen "^2.13.0"
     uppercamelcase "^1.1.0"
 
-react-docgen@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.13.0.tgz#7fcc4a3104ea8d4fd428383ba38df11166837be9"
+react-docgen@^2.13.0, react-docgen@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.15.0.tgz#11aced462256e4862b14e6af6e46bdcefacb28bb"
   dependencies:
-    async "^1.4.2"
+    async "^2.1.4"
     babel-runtime "^6.9.2"
     babylon "~5.8.3"
     commander "^2.9.0"
@@ -2061,7 +2094,7 @@ shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
 
-sigmund@~1.0.0:
+sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
@@ -2297,6 +2330,13 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript-formatter@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typescript-formatter/-/typescript-formatter-5.2.0.tgz#cd45294f74c4cc880f48f81983a21fb264f6f173"
+  dependencies:
+    commandpost "^1.0.0"
+    editorconfig "^0.13.2"
+
 typescript@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
@@ -2331,6 +2371,12 @@ uppercamelcase@^1.1.0:
   resolved "https://registry.yarnpkg.com/uppercamelcase/-/uppercamelcase-1.1.0.tgz#324d98a6b3afc7e8a8953e10641509b0e4e23f97"
   dependencies:
     camelcase "^1.2.1"
+
+uppercamelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uppercamelcase/-/uppercamelcase-3.0.0.tgz#380b321b8d73cba16fec4d752a575152d1ef7317"
+  dependencies:
+    camelcase "^4.1.0"
 
 urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Встречаем новый велосипед!
 Что сделано?  
1) генерация интерфейсов пропсов (как раньше)
2) генерация дефинишенов для публичных методов
3) генерация пропсов для композитных компонентов
4) отказался от сторонней либы, которая по сути более слабый проект чем react-doc-gen

Кодогенерация тут упрощена до нельзя.
На всякий случай заюзал форматтер

Что планируется?
1) Генерить нормально типы - в прошлой и в этой реализации типы для пропсов генерятся как any;
2) Сделать полноценное наследование пропсов для композитных компонентов (почти сделал но есть разные кейсы. Нужно обсуждать)
https://github.com/alfa-laboratory/arui-feather/pull/38