### PR TITLE
feat(*): use react-docgen v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-sourcemaps": "^2.6.0",
     "gulp-typescript": "^3.2.1",
     "react-component-info": "^1.1.1",
-    "react-docgen": "^2.15.0",
+    "react-docgen": "^3.0.0-beta8",
     "react-docgen-displayname-handler": "^1.0.0",
     "recast": "^0.12.5",
     "resolve": "^1.3.3",


### PR DESCRIPTION
Текущая версия `react-docgen` подтягивала `babylon` v5.
`"babylon": "~5.8.3"`

Тогда как для корректного парсинга динамических импортов нужен минимум `6.12.0`:
https://github.com/babel/babylon/releases/tag/v6.12.0

В итоге демо на `react-styleguidist`, которое внутри тянет `react-docgen` успешно ломалось с `Unexpected token` на `import()`.