### PR TITLE
fix-duplicate-declaration

### DIFF
--- a/typings/stringify-component-definition.js
+++ b/typings/stringify-component-definition.js
@@ -2,10 +2,16 @@
 const upperCamelCase = require('uppercamelcase');
 
 function stringifyType(type, componentName, propName, typeRefs) {
-    const typeName = `${componentName}${upperCamelCase(propName)}FieldType`;
+    let typeName = `${componentName}${upperCamelCase(propName)}`;
 
     if (typeof type === 'string' || !type) {
         type = { name: type };
+    }
+
+    if (type.name === 'shape') {
+        typeName = `${typeName}ShapeType`;
+    } else {
+        typeName = `${typeName}FieldType`;
     }
 
     switch (type.name) {


### PR DESCRIPTION
Сейчас для shape происходит дублирование

`ERROR in /Users/malyakin_kirill/WebstormProjects/stub-ui/node_modules/arui-feather/grid-col/grid-col.d.ts(23,13):
TS2300: Duplicate identifier 'GridColOffsetFieldType'.
ERROR in /Users/malyakin_kirill/WebstormProjects/stub-ui/node_modules/arui-feather/grid-col/grid-col.d.ts(37,13):
TS2300: Duplicate identifier 'GridColOffsetFieldType'.
ERROR in /Users/malyakin_kirill/WebstormProjects/stub-ui/node_modules/arui-feather/grid-row/grid-row.d.ts(22,13):
TS2300: Duplicate identifier 'GridRowGutterFieldType'.
ERROR in /Users/malyakin_kirill/WebstormProjects/stub-ui/node_modules/arui-feather/grid-row/grid-row.d.ts(27,13):
TS2300: Duplicate identifier 'GridRowGutterFieldType'.`