### PR TITLE
Fix/simplify typings

### DIFF
--- a/typings/__tests__/__snapshots__/index.tests.js.snap
+++ b/typings/__tests__/__snapshots__/index.tests.js.snap
@@ -105,7 +105,7 @@ export type AProps = DeepReadonlyObject<{
 }>;
 
 
-export type APropTypes = Record<keyof AProps, Type.Validator<any>>;
+export type APropTypes = Type.ValidationMap<AProps>;
 
 
 /**

--- a/typings/__tests__/__snapshots__/index.tests.js.snap
+++ b/typings/__tests__/__snapshots__/index.tests.js.snap
@@ -29,7 +29,7 @@ export type AOptionalObjectOfFieldType = {
 export type ARequiredObjectOfFieldType = {
     [key: string]: number;
 };
-export type AOptionalObjectWithShapeSubShapeFieldType = {
+export type AOptionalObjectWithShapeSubShapeShapeType = {
 
     /**
      * Even deeper documentation
@@ -37,7 +37,7 @@ export type AOptionalObjectWithShapeSubShapeFieldType = {
     name?: string;
     size?: number
 };
-export type AOptionalObjectWithShapeFieldType = {
+export type AOptionalObjectWithShapeShapeType = {
     color?: string;
 
     /**
@@ -49,7 +49,7 @@ export type AOptionalObjectWithShapeFieldType = {
      * @param {string} value
      */
     onChange?: Function;
-    subShape?: AOptionalObjectWithShapeSubShapeFieldType
+    subShape?: AOptionalObjectWithShapeSubShapeShapeType
 };
 export type AOnClickReturnFieldType = string | number;
 export type APublicWithParamsUnionParamFieldType = string | number;
@@ -94,7 +94,7 @@ export type AProps = DeepReadonlyObject<{
     requiredObjectOf: ARequiredObjectOfFieldType;
     optionalAny?: any;
     requiredAny: any;
-    optionalObjectWithShape?: AOptionalObjectWithShapeFieldType;
+    optionalObjectWithShape?: AOptionalObjectWithShapeShapeType;
 
     /**
      * Callback with documentation
@@ -105,7 +105,7 @@ export type AProps = DeepReadonlyObject<{
 }>;
 
 
-export type APropTypes = Record<keyof AProps, Type.Validator<AProps>>;
+export type APropTypes = Record<keyof AProps, Type.Validator<any>>;
 
 
 /**

--- a/typings/stringify-component-definition.js
+++ b/typings/stringify-component-definition.js
@@ -199,7 +199,7 @@ function stringifyComponentDefinition(info) {
 
         ${propsDef}
         
-        export type ${propTypesTypeName} = Record<keyof ${propsInterfaceName}, Type.Validator<${propsInterfaceName}>>;
+        export type ${propTypesTypeName} = Record<keyof ${propsInterfaceName}, Type.Validator<any>>;
 
         ${stringifyDescription(info.description, info.docblock)}
         export default class ${info.displayName} extends React.Component<${propsInterfaceName}> {

--- a/typings/stringify-component-definition.js
+++ b/typings/stringify-component-definition.js
@@ -199,7 +199,7 @@ function stringifyComponentDefinition(info) {
 
         ${propsDef}
         
-        export type ${propTypesTypeName} = Record<keyof ${propsInterfaceName}, Type.Validator<any>>;
+        export type ${propTypesTypeName} = Type.ValidationMap<${propsInterfaceName}>;
 
         ${stringifyDescription(info.description, info.docblock)}
         export default class ${info.displayName} extends React.Component<${propsInterfaceName}> {


### PR DESCRIPTION
TS с недавнего времени начал анализировать типы из propTypes, и из-за этого для полей, у которых не получилось сгенерировать тип он не выводит вообще никакого типа, и считает что их попросту нет.
Чиним эту проблему, используем более грамотный вариант выведения типа 