### PR TITLE
fix(*): fix typings section in package.json

### DIFF
--- a/gulp/component-package.js
+++ b/gulp/component-package.js
@@ -16,7 +16,7 @@ function getComponentPackage(file) {
         || fs.existsSync(path.join(dirname, 'index.ts'));
     return JSON.stringify({
         main: isIndexFileExist ? 'index.js' : `${componentName}.js`,
-        types: `${componentName}.d.ts`
+        types: isIndexFileExist ? 'index.d.ts' : `${componentName}.d.ts`
     });
 }
 


### PR DESCRIPTION
Генерирует неправильную ссылку на typings если есть index.js