### PR TITLE
fix(gulp-tasks): добавляет игнор ошибок для TS

### DIFF
--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -185,6 +185,7 @@ function createTasks(packageName, options = {}) {
                     .replace(/\.tsx?$/, '.d.ts')
             )))
             .pipe(ts(tsOptions, ts.reporter.nullReporter())) // ignore all errors at compile time
+            .on('error', () => {}) // ignore all errors at compile time gulp 3 compatible
             .dts.pipe(gulp.dest(options.publishDir));
     }));
 


### PR DESCRIPTION
Дано: компиляция внутреннего npm пакета,  не проходит нормально, пишет
```
[09:37:40] Starting '<anonymous>'...
[09:37:42] '<anonymous>' errored after 2.23 s
[09:37:42] Error: TypeScript: Compilation failed
    at Output.mightFinish (C:\sessions\node_modules\gulp-typescript\release\output.js:130:43)
    at C:\sessions\node_modules\gulp-typescript\release\output.js:65:22
[09:37:42] 'dts' errored after 4.35 s
[09:37:42] 'compile' errored after 8.69 s
error Command failed with exit code 1.
```

ошибка чинится данным фиксом, который в доке указан как совместимый для gulp 3
https://github.com/ivogabe/gulp-typescript#gulp-3
Хотя я использую gulp 4. Вот тут автор gulp-typescript пишет, что это норм: https://github.com/ivogabe/gulp-typescript/issues/295#issuecomment-396382079