### PR TITLE
feat(gulp-tasks): added tsCompiler for 'ts:compile'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gulpfile
 "compile": "gulp --cwd . --gulpfile ./node_modules/library-utils/gulpfile.js compile",
 ```
 
-Для более тонкой настройки используйте gulp-tasks.
+Для более тонкой настройки используйте gulp-tasks или настройки в `package.json`.
 
 gulp-tasks
 ----------
@@ -52,7 +52,8 @@ createTasks('arui-feather');
 * `options` - не обязательный. Настройки путей.
   * `publishDir` - имя папки для публикации, туда будут записываться скомпилированные файлы
   * `docsDir` - имя папки для документации
-  * `tsConfigFilename` - путь до файла с конфигурацией typescript.
+  * `tsCompiler` - компилятор для typescript
+  * `tsConfigFilename` - путь до файла с конфигурацией typescript
   * `componentsGlob` - glob для файлов js компонентов
   * `tsComponentsGlob` - glob для файлов ts компонентов
   * `jsGlob` - glob для всех публикуемых js файлов пакета
@@ -62,6 +63,22 @@ createTasks('arui-feather');
   * `cssCopyGlob` - glob для всех копируемых css фалов пакета
   * `resourcesGlob` - glob для всех ресурсных файлов пакета (картинки, шрифты)
   * `publishFilesGlob` - glob для всех дополнительных файлов, которые должны попасть в публикацию
+
+Настройки в `package.json`
+----------------
+
+Так же можно указать нужные свойства из `options` в ключе `library-utils`
+
+Пример `package.json` вашего проекта:
+```
+{
+    "name": "arui-feather",
+    "library-utils": {
+        "publishDir": ".my-custom-publish-dir",
+        "tsCompiler": "my-fork-of-typescript",
+    }
+}
+```
 
 componentPackage
 ----------------

--- a/gulp-tasks.js
+++ b/gulp-tasks.js
@@ -66,7 +66,13 @@ function createTasks(packageName, options = {}) {
     );
 
     gulp.task('ts:compile', () => {
-        const tsProject = ts.createProject(options.tsConfigFilename, { declaration: true });
+        const tsProjectSettings = { declaration: true };
+
+        if (options.tsCompiler) {
+            tsProjectSettings.typescript = require(options.tsCompiler);
+        }
+
+        const tsProject = ts.createProject(options.tsConfigFilename, tsProjectSettings);
         const tsResult = gulp.src(options.tsGlob)
             .pipe(sourcemaps.init())
             .pipe(tsProject())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,10 +2,8 @@ const path = require('path');
 const fs = require('fs');
 const createTasks = require('./gulp-tasks');
 
-function findPackageName() {
-    const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const appPackage = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name;
-}
 
-createTasks(findPackageName());
+createTasks(appPackage.name, appPackage['library-utils']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,5 +5,4 @@ const createTasks = require('./gulp-tasks');
 const packageJsonPath = path.resolve(process.cwd(), 'package.json');
 const appPackage = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-
 createTasks(appPackage.name, appPackage['library-utils']);


### PR DESCRIPTION
Добавлен параметр `tsCompiler` в `options`

## Мотивация и контекст
Захотелось использовать https://github.com/cevek/ttypescript совместно с https://github.com/LeDDGroup/typescript-transform-paths для резолва путей при компиляции